### PR TITLE
Add cross-stage validations and automatic scheduling

### DIFF
--- a/src/Angor/Avalonia/AngorApp/Sections/Founder/CreateProject/CreateProjectViewModel.cs
+++ b/src/Angor/Avalonia/AngorApp/Sections/Founder/CreateProject/CreateProjectViewModel.cs
@@ -1,4 +1,5 @@
 using System.Reactive.Disposables;
+using System.Reactive.Linq;
 using System.Threading.Tasks;
 using Angor.Contexts.Funding.Projects.Application.Dtos;
 using Angor.Contexts.Funding.Projects.Infrastructure.Interfaces;
@@ -9,6 +10,7 @@ using AngorApp.Sections.Founder.CreateProject.Stages;
 using AngorApp.Sections.Shell;
 using AngorApp.UI.Controls.Common;
 using AngorApp.UI.Services;
+using ReactiveUI;
 using ReactiveUI.Validation.Extensions;
 using ReactiveUI.Validation.Helpers;
 using Zafiro.Avalonia.Dialogs;
@@ -24,9 +26,15 @@ public class CreateProjectViewModel : ReactiveValidationObject, ICreateProjectVi
     public CreateProjectViewModel(IWallet wallet, UIServices uiServices, IProjectAppService projectAppService)
     {
         this.projectAppService = projectAppService;
-        StagesViewModel = new StagesViewModel().DisposeWith(disposable);
         FundingStructureViewModel = new FundingStructureViewModel().DisposeWith(disposable);
+        var endDateChanges = FundingStructureViewModel.WhenAnyValue(x => x.EndDate);
+        StagesViewModel = new StagesViewModel(() => FundingStructureViewModel.EndDate, endDateChanges).DisposeWith(disposable);
         ProfileViewModel = new ProfileViewModel().DisposeWith(disposable);
+
+        StagesViewModel.LastStageDate
+            .Select(date => date?.AddDays(60))
+            .Subscribe(date => FundingStructureViewModel.ExpiryDate = date)
+            .DisposeWith(disposable);
 
         this.ValidationRule(StagesViewModel.IsValid, b => b, _ => "Stages are not valid").DisposeWith(disposable);
         this.ValidationRule(FundingStructureViewModel.IsValid, b => b, _ => "Funding structures not valid").DisposeWith(disposable);

--- a/src/Angor/Avalonia/AngorApp/Sections/Founder/CreateProject/FundingStructure/FundingStructureViewModel.cs
+++ b/src/Angor/Avalonia/AngorApp/Sections/Founder/CreateProject/FundingStructure/FundingStructureViewModel.cs
@@ -8,7 +8,7 @@ namespace AngorApp.Sections.Founder.CreateProject.FundingStructure;
 public partial class FundingStructureViewModel : ReactiveValidationObject, IFundingStructureViewModel
 {
     [Reactive] private long? sats;
-    [Reactive] private int? penaltyDays = 60;
+    [Reactive] private int? penaltyDays = 100;
     [Reactive] private DateTime? endDate;
     [Reactive] private DateTime? expiryDate;
     [ObservableAsProperty] private IAmountUI targetAmount;

--- a/src/Angor/Avalonia/AngorApp/Sections/Founder/CreateProject/Stages/CreateProjectStage.cs
+++ b/src/Angor/Avalonia/AngorApp/Sections/Founder/CreateProject/Stages/CreateProjectStage.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Reactive.Linq;
+using ReactiveUI;
 using ReactiveUI.SourceGenerators;
 using ReactiveUI.Validation.Extensions;
 using ReactiveUI.Validation.Helpers;
@@ -13,12 +16,17 @@ public partial class CreateProjectStage : ReactiveValidationObject, ICreateProje
     [Reactive]
     private decimal? percent;
 
-    public CreateProjectStage(Action<ICreateProjectStage> remove)
+    public CreateProjectStage(Action<ICreateProjectStage> remove, IObservable<DateTime?> fundingEndDate)
     {
         Remove = ReactiveCommand.Create(() => remove(this)).Enhance();
         this.ValidationRule(stage => stage.Percent, x => x is >= 1, "Percent must be greater than 1");
         this.ValidationRule(stage => stage.Percent, x => x != null, "Enter a percentage");
-        this.ValidationRule(stage => stage.ReleaseDate, x => x != null, "Enter a relase date");
+        this.ValidationRule(stage => stage.ReleaseDate, x => x != null, "Enter a release date");
+
+        var isAfterEndDate = this.WhenAnyValue(stage => stage.ReleaseDate)
+            .CombineLatest(fundingEndDate, (release, end) => release != null && end != null && release > end);
+
+        this.ValidationRule(isAfterEndDate, b => b, _ => "Release date must be after funding end date");
     }
 
     public IEnhancedCommand Remove { get; }

--- a/src/Angor/Avalonia/AngorApp/Sections/Founder/CreateProject/Stages/IStagesViewModel.cs
+++ b/src/Angor/Avalonia/AngorApp/Sections/Founder/CreateProject/Stages/IStagesViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using Zafiro.UI.Commands;
 
 namespace AngorApp.Sections.Founder.CreateProject.Stages;
@@ -7,4 +8,5 @@ public interface IStagesViewModel
     IEnhancedCommand AddStage { get; }
     ICollection<ICreateProjectStage> Stages { get; }
     IObservable<bool> IsValid { get; }
+    IObservable<DateTime?> LastStageDate { get; }
 }

--- a/src/Angor/Avalonia/AngorApp/Sections/Founder/CreateProject/Stages/StagesViewModel.cs
+++ b/src/Angor/Avalonia/AngorApp/Sections/Founder/CreateProject/Stages/StagesViewModel.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using DynamicData;
+using ReactiveUI;
 using ReactiveUI.Validation.Extensions;
 using ReactiveUI.Validation.Helpers;
 using Zafiro.UI.Commands;
@@ -12,26 +14,42 @@ namespace AngorApp.Sections.Founder.CreateProject.Stages;
 public class StagesViewModel : ReactiveValidationObject, IStagesViewModel
 {
     private readonly CompositeDisposable disposable = new();
-    
+    private readonly Func<DateTime?> getEndDate;
+    private readonly IObservable<DateTime?> endDateChanges;
+
     public IEnhancedCommand AddStage { get; }
-    
+
     private readonly SourceCache<ICreateProjectStage, long> stagesSource;
 
-    public StagesViewModel()
+    public StagesViewModel(Func<DateTime?> getEndDate, IObservable<DateTime?> endDateChanges)
     {
+        this.getEndDate = getEndDate;
+        this.endDateChanges = endDateChanges;
+
         stagesSource = new SourceCache<ICreateProjectStage, long>(stage => stage.GetHashCode())
             .DisposeWith(disposable);
 
         var changes = stagesSource.Connect();
-        
+
+        LastStageDate = changes
+            .AutoRefresh(stage => stage.ReleaseDate)
+            .ToCollection()
+            .Select(list => list.Select(s => s.ReleaseDate).Where(d => d.HasValue).DefaultIfEmpty().Max())
+            .Replay(1)
+            .RefCount();
+
         changes
             .Bind(out var stages)
             .Subscribe()
             .DisposeWith(disposable);
-        
+
         Stages = stages;
-        
-        AddStage = ReactiveCommand.Create(() => stagesSource.AddOrUpdate(CreateStage())).Enhance()
+
+        AddStage = ReactiveCommand.Create(() =>
+        {
+            stagesSource.AddOrUpdate(CreateStage());
+            RecalculatePercentages();
+        }).Enhance()
             .DisposeWith(disposable);
         
         // Combinar directamente los observables IsValid() de cada stage
@@ -50,21 +68,41 @@ public class StagesViewModel : ReactiveValidationObject, IStagesViewModel
             .AutoRefresh(stage => stage.Percent)
             .ToCollection()
             .Select(list => list.Sum(stage => stage.Percent ?? 0));
-        
+
         this.ValidationRule(totalPercent, percent => Math.Abs(percent - 100) < 1, _ => "Stages percentajes should sum to 100%").DisposeWith(disposable);
-        
+
         stagesSource.AddOrUpdate(CreateStage());
+        RecalculatePercentages();
     }
 
     public ICollection<ICreateProjectStage> Stages { get; }
 
     private CreateProjectStage CreateStage()
     {
-        return new CreateProjectStage(stage => stagesSource.Remove(stage))
+        return new CreateProjectStage(stage =>
+        {
+            stagesSource.Remove(stage);
+            RecalculatePercentages();
+        }, endDateChanges)
         {
             Percent = 100,
-            ReleaseDate = DateTime.Now
+            ReleaseDate = (getEndDate() ?? DateTime.Now).AddDays(7)
         };
+    }
+
+    private void RecalculatePercentages()
+    {
+        var count = stagesSource.Count;
+        if (count == 0)
+        {
+            return;
+        }
+
+        var percent = 100m / count;
+        foreach (var stage in stagesSource.Items)
+        {
+            stage.Percent = percent;
+        }
     }
 
     protected override void Dispose(bool disposing)
@@ -74,4 +112,5 @@ public class StagesViewModel : ReactiveValidationObject, IStagesViewModel
     }
 
     public IObservable<bool> IsValid => this.IsValid();
+    public IObservable<DateTime?> LastStageDate { get; }
 }

--- a/src/Angor/Avalonia/AngorApp/Sections/Founder/CreateProject/Stages/StagesViewModelDesign.cs
+++ b/src/Angor/Avalonia/AngorApp/Sections/Founder/CreateProject/Stages/StagesViewModelDesign.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Reactive.Linq;
 using Zafiro.UI.Commands;
 
 namespace AngorApp.Sections.Founder.CreateProject.Stages;
@@ -6,5 +8,6 @@ public class StagesViewModelDesign : IStagesViewModel
 {
     public IEnhancedCommand AddStage { get; }
     public ICollection<ICreateProjectStage> Stages { get; } = new List<ICreateProjectStage>();
-    public IObservable<bool> IsValid { get; }
+    public IObservable<bool> IsValid { get; } = Observable.Return(true);
+    public IObservable<DateTime?> LastStageDate { get; } = Observable.Return<DateTime?>(DateTime.Now);
 }


### PR DESCRIPTION
## Summary
- validate stage release dates against funding end date and redistribute stage percentages
- default penalty days to 100 and compute emergency expiry 60 days after last stage
- auto-set new stage dates 7 days after funding end and update expiry on stage changes

## Testing
- `/usr/share/dotnet/dotnet test src/Angor.sln`

------
https://chatgpt.com/codex/tasks/task_e_68aecb76b82c832f969743e503ad950f