### PR TITLE
Ensure SVG icons update with theme changes

### DIFF
--- a/src/Angor/Avalonia/AngorApp/UI/AngorIconConverter.cs
+++ b/src/Angor/Avalonia/AngorApp/UI/AngorIconConverter.cs
@@ -1,9 +1,10 @@
+using System;
+using System.IO;
 using System.Xml.Linq;
 using Avalonia;
 using Avalonia.Platform;
 using Avalonia.Styling;
 using Zafiro.Avalonia;
-using Zafiro.Reactive;
 
 namespace AngorApp.UI;
 
@@ -13,41 +14,55 @@ public class AngorIconConverter : IIconConverter
     
     public Control? Convert(Zafiro.UI.IIcon icon)
     {
-        // 1. División en dos partes: esquema y resto
-        var parts = icon.Source.Split(new[] { ':' }, 2);
+        return TryCreateSvgIcon(icon.Source)
+            .Match<Control?>(
+                themedIcon => themedIcon,
+                () => new Projektanker.Icons.Avalonia.Icon { Value = icon.Source });
+    }
+
+    private static Maybe<ThemedSvgIcon> TryCreateSvgIcon(string source)
+    {
+        return Parse(source).Map(resource => new ThemedSvgIcon(resource));
+    }
+
+    private static Maybe<SvgResource> Parse(string source)
+    {
+        var parts = source.Split(new[] { ':' }, 2);
         if (parts.Length != 2 || parts[0] != "svg")
-            return new Projektanker.Icons.Avalonia.Icon() { Value = icon.Source };
+        {
+            return Maybe<SvgResource>.None;
+        }
 
         var remainder = parts[1];
-        string assemblyName;
-        string resourcePath;
 
-        // 2. Formato implícito: /ruta → ensamblado actual
-        if (remainder.StartsWith("/"))
-        {
-            assemblyName = Application.Current!.GetType().Assembly.GetName().Name!;
-            resourcePath = remainder.TrimStart('/');
-        }
-        else
-        {
-            // 3. Formato explícito: NombreEnsamblado/ruta
-            var idx = remainder.IndexOf('/');
-            if (idx <= 0)
-                return new Projektanker.Icons.Avalonia.Icon { Value = icon.Source }; // formato inválido
+        return remainder.StartsWith("/")
+            ? FromImplicitPath(remainder)
+            : FromExplicitPath(remainder);
+    }
 
-            assemblyName = remainder[..idx];
-            resourcePath = remainder[(idx + 1)..];
+    private static Maybe<SvgResource> FromImplicitPath(string remainder)
+    {
+        var assemblyName = Application.Current?.GetType().Assembly.GetName().Name;
+        if (string.IsNullOrWhiteSpace(assemblyName))
+        {
+            return Maybe<SvgResource>.None;
         }
 
-        var uri = new Uri($"avares://{assemblyName}");
+        var resourcePath = remainder.TrimStart('/');
+        return SvgResource.Create(assemblyName, resourcePath);
+    }
 
-        var isLight = Application.Current?.ActualThemeVariant == ThemeVariant.Light;
-        var color = isLight ? "Black" : "White";
-        var svgContents = AssetLoader.Open(new Uri(uri, resourcePath)).ReadToEnd().Result;
-        var transformer = new AngorSvgTransformer(color);
-        var final = transformer.Transform(svgContents);
+    private static Maybe<SvgResource> FromExplicitPath(string remainder)
+    {
+        var index = remainder.IndexOf('/');
+        if (index <= 0)
+        {
+            return Maybe<SvgResource>.None;
+        }
 
-        return new global::Avalonia.Svg.Skia.Svg(uri) { Source = final };
+        var assemblyName = remainder[..index];
+        var resourcePath = remainder[(index + 1)..];
+        return SvgResource.Create(assemblyName, resourcePath);
     }
 }
 
@@ -73,5 +88,69 @@ public class AngorSvgTransformer(string color)
         }
 
         return svg.ToString();
+    }
+}
+
+public sealed class ThemedSvgIcon : global::Avalonia.Svg.Skia.Svg
+{
+    private readonly string svgContent;
+    private IDisposable? themeSubscription;
+
+    public ThemedSvgIcon(SvgResource resource)
+    {
+        svgContent = LoadSvg(resource.AssetUri);
+        UpdateIcon(GetCurrentThemeVariant());
+    }
+
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        UpdateIcon(GetCurrentThemeVariant());
+
+        themeSubscription = this
+            .GetObservable(ThemeVariantScope.ActualThemeVariantProperty)
+            .Subscribe(_ => UpdateIcon(GetCurrentThemeVariant()));
+    }
+
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        themeSubscription?.Dispose();
+        themeSubscription = null;
+        base.OnDetachedFromVisualTree(e);
+    }
+
+    private void UpdateIcon(ThemeVariant themeVariant)
+    {
+        var color = themeVariant == ThemeVariant.Light ? "Black" : "White";
+        var transformer = new AngorSvgTransformer(color);
+        Source = transformer.Transform(svgContent);
+    }
+
+    private ThemeVariant GetCurrentThemeVariant()
+    {
+        return ActualThemeVariant ?? Application.Current?.ActualThemeVariant ?? ThemeVariant.Light;
+    }
+
+    private static string LoadSvg(Uri uri)
+    {
+        using var stream = AssetLoader.Open(uri);
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+}
+
+public sealed record SvgResource(Uri BaseUri, string ResourcePath)
+{
+    public Uri AssetUri => new(BaseUri, ResourcePath);
+
+    public static Maybe<SvgResource> Create(string assemblyName, string resourcePath)
+    {
+        if (string.IsNullOrWhiteSpace(assemblyName) || string.IsNullOrWhiteSpace(resourcePath))
+        {
+            return Maybe<SvgResource>.None;
+        }
+
+        var baseUri = new Uri($"avares://{assemblyName}");
+        return Maybe.From(new SvgResource(baseUri, resourcePath));
     }
 }


### PR DESCRIPTION
## Summary
- refactor AngorIconConverter to produce themed SVG controls via functional parsing helpers
- add a ThemedSvgIcon control that caches SVG content and listens for ThemeVariant updates

## Testing
- `dotnet build src/Angor/Avalonia/Angor.Avalonia.sln` *(fails: missing .NET SDK 8.0.310 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d90d0282ec832fbf71fb3c966e64ab