### PR TITLE
Refresh themed SVG icons on theme changes

### DIFF
--- a/src/Angor/Avalonia/AngorApp/UI/AngorIconConverter.cs
+++ b/src/Angor/Avalonia/AngorApp/UI/AngorIconConverter.cs
@@ -1,9 +1,14 @@
+using System;
+using System.IO;
+using System.Reactive.Linq;
 using System.Xml.Linq;
 using Avalonia;
+using Avalonia.Controls;
 using Avalonia.Platform;
 using Avalonia.Styling;
+using Avalonia.VisualTree;
+using CSharpFunctionalExtensions;
 using Zafiro.Avalonia;
-using Zafiro.Reactive;
 
 namespace AngorApp.UI;
 
@@ -13,47 +18,96 @@ public class AngorIconConverter : IIconConverter
     
     public Control? Convert(Zafiro.UI.IIcon icon)
     {
-        // 1. División en dos partes: esquema y resto
-        var parts = icon.Source.Split(new[] { ':' }, 2);
-        if (parts.Length != 2 || parts[0] != "svg")
-            return new Projektanker.Icons.Avalonia.Icon() { Value = icon.Source };
+        return Parse(icon.Source)
+            .Map(resource => (Control)new ThemeAwareSvgIcon(resource))
+            .GetValueOrDefault(new Projektanker.Icons.Avalonia.Icon { Value = icon.Source });
+    }
 
-        var remainder = parts[1];
-        string assemblyName;
-        string resourcePath;
+    private static Result<SvgResource> Parse(string source)
+    {
+        return Result.Success(source)
+            .Ensure(s => s.StartsWith("svg:"), "Not an svg resource")
+            .Map(s => s.Split(new[] { ':' }, 2)[1])
+            .Bind(CreateDescriptor)
+            .Bind(BuildResource);
+    }
 
-        // 2. Formato implícito: /ruta → ensamblado actual
+    private static Result<ResourceDescriptor> CreateDescriptor(string remainder)
+    {
         if (remainder.StartsWith("/"))
         {
-            assemblyName = Application.Current!.GetType().Assembly.GetName().Name!;
-            resourcePath = remainder.TrimStart('/');
+            var assemblyName = Application.Current!.GetType().Assembly.GetName().Name!;
+            return Result.Success(new ResourceDescriptor(assemblyName, remainder.TrimStart('/')));
         }
-        else
+
+        var separatorIndex = remainder.IndexOf('/');
+
+        return separatorIndex > 0
+            ? Result.Success(new ResourceDescriptor(remainder[..separatorIndex], remainder[(separatorIndex + 1)..]))
+            : Result.Failure<ResourceDescriptor>("Invalid svg resource path");
+    }
+
+    private static Result<SvgResource> BuildResource(ResourceDescriptor descriptor)
+    {
+        var baseUri = new Uri($"avares://{descriptor.Assembly}");
+
+        return LoadSvg(baseUri, descriptor.Path)
+            .Map(content => new SvgResource(baseUri, content));
+    }
+
+    private static Result<string> LoadSvg(Uri baseUri, string resourcePath)
+    {
+        return Result.Try(() =>
         {
-            // 3. Formato explícito: NombreEnsamblado/ruta
-            var idx = remainder.IndexOf('/');
-            if (idx <= 0)
-                return new Projektanker.Icons.Avalonia.Icon { Value = icon.Source }; // formato inválido
+            using var stream = AssetLoader.Open(new Uri(baseUri, resourcePath));
+            using var reader = new StreamReader(stream);
+            return reader.ReadToEnd();
+        });
+    }
 
-            assemblyName = remainder[..idx];
-            resourcePath = remainder[(idx + 1)..];
+    private sealed record ResourceDescriptor(string Assembly, string Path);
+
+    private sealed record SvgResource(Uri BaseUri, string Content);
+
+    private sealed class ThemeAwareSvgIcon : global::Avalonia.Svg.Skia.Svg
+    {
+        private readonly SvgResource resource;
+        private IDisposable? subscription;
+
+        public ThemeAwareSvgIcon(SvgResource resource) : base(resource.BaseUri)
+        {
+            this.resource = resource;
         }
 
-        var uri = new Uri($"avares://{assemblyName}");
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
 
-        var isLight = Application.Current?.ActualThemeVariant == ThemeVariant.Light;
-        var color = isLight ? "Black" : "White";
-        var svgContents = AssetLoader.Open(new Uri(uri, resourcePath)).ReadToEnd().Result;
-        var transformer = new AngorSvgTransformer(color);
-        var final = transformer.Transform(svgContents);
+            UpdateSource();
+            subscription ??= this.GetObservable(ThemeVariantScope.ActualThemeVariantProperty)
+                .Subscribe(_ => UpdateSource());
+        }
 
-        return new global::Avalonia.Svg.Skia.Svg(uri) { Source = final };
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnDetachedFromVisualTree(e);
+
+            subscription?.Dispose();
+            subscription = null;
+        }
+
+        private void UpdateSource()
+        {
+            var theme = ActualThemeVariant ?? Application.Current?.ActualThemeVariant;
+            var color = theme == ThemeVariant.Light ? "Black" : "White";
+            Source = AngorSvgTransformer.Transform(resource.Content, color);
+        }
     }
 }
 
-public class AngorSvgTransformer(string color)
+public static class AngorSvgTransformer
 {
-    public string Transform(string svgContent)
+    public static string Transform(string svgContent, string color)
     {
         var svg = XElement.Parse(svgContent);
 


### PR DESCRIPTION
## Summary
- return a theme-aware SVG control from the icon converter that updates the rendered source whenever the theme changes
- load and cache the original SVG content once and reuse it with a color transform for each theme update

## Testing
- dotnet build src/Angor/Avalonia/AngorApp/AngorApp.csproj *(fails: missing .NET SDK 8.0.310 in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d90d0282ec832fbf71fb3c966e64ab