### PR TITLE
Add instance profile support

### DIFF
--- a/src/Angor/Avalonia/Angor.Contexts.Wallet/Infrastructure/Impl/FileStore.cs
+++ b/src/Angor/Avalonia/Angor.Contexts.Wallet/Infrastructure/Impl/FileStore.cs
@@ -1,3 +1,5 @@
+using System;
+using System.IO;
 using System.Text.Json;
 using Angor.Contests.CrossCutting;
 using CSharpFunctionalExtensions;
@@ -7,9 +9,11 @@ namespace Angor.Contexts.Wallet.Infrastructure.Impl;
 public class FileStore : IStore
 {
     private readonly string appDataPath;
+    private readonly string instancePrefix;
 
-    public FileStore(string appName)
+    public FileStore(string appName, string instancePrefix)
     {
+        this.instancePrefix = instancePrefix;
         appDataPath = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             appName
@@ -20,7 +24,7 @@ public class FileStore : IStore
 
     public async Task<Result> Save<T>(string key, T data)
     {
-        return from filePath in Result.Try(() => Path.Combine(appDataPath, key))
+        return from filePath in Result.Try(() => BuildPath(key))
             from contents in Result.Try(() => JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true }))
             select Result.Try(() => File.WriteAllTextAsync(filePath, contents))
                 .Bind(Result.Success);
@@ -28,13 +32,30 @@ public class FileStore : IStore
 
     public Task<Result<T>> Load<T>(string key)
     {
-        return Result.Try(() => Path.Combine(appDataPath, key))
+        return Result.Try(() => BuildPath(key))
             .TapTry(CreateFile)
             .MapTry(s => File.ReadAllTextAsync(s))
             .Bind(json => Result.Try(() => JsonSerializer.Deserialize<T>(json))
                 .Ensure(x => x != null, $"Could not deserialize {json} as {typeof(T)}")
                 .Map(x => x!)
             );
+    }
+
+    private string BuildPath(string key)
+    {
+        var folder = RequiresInstancePrefix(key)
+            ? Path.Combine(appDataPath, instancePrefix)
+            : appDataPath;
+
+        Directory.CreateDirectory(folder);
+
+        return Path.Combine(folder, key);
+    }
+
+    private static bool RequiresInstancePrefix(string key)
+    {
+        return string.Equals(key, "wallets.json", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(key, "settings.json", StringComparison.OrdinalIgnoreCase);
     }
 
     private static void CreateFile(string path)

--- a/src/Angor/Avalonia/AngorApp.Desktop/ProfileArgument.cs
+++ b/src/Angor/Avalonia/AngorApp.Desktop/ProfileArgument.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CSharpFunctionalExtensions;
+using AngorApp.Core;
+
+namespace AngorApp.Desktop;
+
+public static class ProfileArgument
+{
+    private const string ProfileOption = "--profile";
+
+    public static string GetProfile(string[] args)
+    {
+        foreach (var (value, index) in args.Select((value, index) => (value, index)))
+        {
+            var profile = ParseProfile(args, value, index);
+            if (profile.HasValue)
+            {
+                return profile.Value;
+            }
+        }
+
+        return InstanceProfileProvider.DefaultProfile.Value;
+    }
+
+    private static Maybe<string> ParseProfile(IReadOnlyList<string> args, string value, int index)
+    {
+        if (!value.StartsWith(ProfileOption, StringComparison.OrdinalIgnoreCase))
+        {
+            return Maybe<string>.None;
+        }
+
+        if (value.Equals(ProfileOption, StringComparison.OrdinalIgnoreCase))
+        {
+            return NextArgument(args, index);
+        }
+
+        var parts = value.Split('=', 2, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length != 2)
+        {
+            return Maybe<string>.None;
+        }
+
+        return Maybe<string>.From(parts[1], string.IsNullOrWhiteSpace);
+    }
+
+    private static Maybe<string> NextArgument(IReadOnlyList<string> args, int index)
+    {
+        var nextIndex = index + 1;
+        if (nextIndex >= args.Count)
+        {
+            return Maybe<string>.None;
+        }
+
+        var nextValue = args[nextIndex];
+        if (nextValue.StartsWith("--", StringComparison.OrdinalIgnoreCase))
+        {
+            return Maybe<string>.None;
+        }
+
+        return Maybe<string>.From(nextValue, string.IsNullOrWhiteSpace);
+    }
+}

--- a/src/Angor/Avalonia/AngorApp.Desktop/Program.cs
+++ b/src/Angor/Avalonia/AngorApp.Desktop/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using AngorApp.Core;
 using Avalonia;
 using Avalonia.ReactiveUI;
 
@@ -10,8 +11,14 @@ sealed class Program
     // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
     // yet and stuff might break.
     [STAThread]
-    public static void Main(string[] args) => BuildAvaloniaApp()
-        .StartWithClassicDesktopLifetime(args);
+    public static void Main(string[] args)
+    {
+        var profile = ProfileArgument.GetProfile(args);
+        InstanceProfileProvider.Configure(profile);
+
+        BuildAvaloniaApp()
+            .StartWithClassicDesktopLifetime(args);
+    }
 
     // Avalonia configuration, don't remove; also used by visual designer.
     public static AppBuilder BuildAvaloniaApp() =>

--- a/src/Angor/Avalonia/AngorApp/App.axaml.cs
+++ b/src/Angor/Avalonia/AngorApp/App.axaml.cs
@@ -1,4 +1,5 @@
 using AngorApp.Composition;
+using AngorApp.Core;
 using AngorApp.Sections.Shell;
 using Avalonia;
 using Avalonia.Markup.Xaml;
@@ -35,7 +36,8 @@ public partial class App : Application
             .Register<MaterialDesignIconProvider>()
             .RegisterPathStringIconProvider("path");
 
-        this.Connect(() => new MainView(), CompositionRoot.CreateMainViewModel, () => new MainWindow());
+        var instanceProfile = InstanceProfileProvider.Current;
+        this.Connect(() => new MainView(), control => CompositionRoot.CreateMainViewModel(control, instanceProfile), () => new MainWindow());
 
         base.OnFrameworkInitializationCompleted();
     }

--- a/src/Angor/Avalonia/AngorApp/Composition/CompositionRoot.cs
+++ b/src/Angor/Avalonia/AngorApp/Composition/CompositionRoot.cs
@@ -11,6 +11,7 @@ using AngorApp.Composition.Registrations;
 using AngorApp.Composition.Registrations.Sections;
 using AngorApp.Composition.Registrations.Services;
 using AngorApp.Composition.Registrations.ViewModels;
+using AngorApp.Core;
 using AngorApp.Sections;
 using AngorApp.Sections.Browse;
 using AngorApp.Sections.Founder;
@@ -32,7 +33,7 @@ namespace AngorApp.Composition;
 
 public static class CompositionRoot
 {
-    public static IMainViewModel CreateMainViewModel(Control topLevelView)
+    public static IMainViewModel CreateMainViewModel(Control topLevelView, InstanceProfile instanceProfile)
     {
         var services = new ServiceCollection();
 
@@ -40,7 +41,7 @@ public static class CompositionRoot
             .WriteTo.Console()
             .MinimumLevel.Debug().CreateLogger();
 
-        var store = new FileStore("Angor");
+        var store = new FileStore("Angor", instanceProfile.Value);
         var networkStorage = new NetworkStorage(store);
         var network = networkStorage.GetNetwork() switch
         {
@@ -62,7 +63,7 @@ public static class CompositionRoot
         services
             .AddModelServices()
             .AddViewModels()
-            .AddUiServices(topLevelView);
+            .AddUiServices(topLevelView, instanceProfile);
         
         services.AddNavigator();
         services.AddSecurityContext();

--- a/src/Angor/Avalonia/AngorApp/Composition/Registrations/Services/UiServices.cs
+++ b/src/Angor/Avalonia/AngorApp/Composition/Registrations/Services/UiServices.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Angor.Shared;
+using AngorApp.Core;
 using AngorApp.Sections.Shell;
 using AngorApp.UI.Services;
 using Avalonia.Controls.Notifications;
@@ -17,7 +18,7 @@ namespace AngorApp.Composition.Registrations.Services;
 public static class UiServices
 {
     // Registers UI-level services, dialogs, shell and notifications
-    public static IServiceCollection AddUiServices(this IServiceCollection services, Control parent)
+    public static IServiceCollection AddUiServices(this IServiceCollection services, Control parent, InstanceProfile instanceProfile)
     {
         var topLevel = TopLevel.GetTopLevel(parent);
         
@@ -39,6 +40,7 @@ public static class UiServices
             .AddSingleton<IWalletRoot, WalletRoot>()
             .AddSingleton<IValidations, Validations>()
             .AddSingleton<INotificationService>(_ => notificationService)
+            .AddSingleton(instanceProfile)
             .AddSingleton<UIServices>();
     }
     

--- a/src/Angor/Avalonia/AngorApp/Core/InstanceProfileProvider.cs
+++ b/src/Angor/Avalonia/AngorApp/Core/InstanceProfileProvider.cs
@@ -1,0 +1,30 @@
+using CSharpFunctionalExtensions;
+
+namespace AngorApp.Core;
+
+public sealed record InstanceProfile
+{
+    public InstanceProfile(string value)
+    {
+        Value = Maybe<string>.From(value, string.IsNullOrWhiteSpace)
+            .GetValueOrDefault(DefaultPrefix);
+    }
+
+    public string Value { get; }
+
+    private const string DefaultPrefix = "Default";
+}
+
+public static class InstanceProfileProvider
+{
+    private static InstanceProfile current = DefaultProfile;
+
+    public static InstanceProfile DefaultProfile { get; } = new InstanceProfile("Default");
+
+    public static InstanceProfile Current => current;
+
+    public static void Configure(string prefix)
+    {
+        current = new InstanceProfile(prefix);
+    }
+}

--- a/src/Angor/Avalonia/AngorApp/UI/Services/UIServices.cs
+++ b/src/Angor/Avalonia/AngorApp/UI/Services/UIServices.cs
@@ -1,3 +1,4 @@
+using AngorApp.Core;
 using AngorApp.UI.Controls;
 using AngorApp.UI.Controls.Feerate;
 using Avalonia;
@@ -21,8 +22,9 @@ public partial class UIServices : ReactiveObject
     
     public UIServices(ILauncherService launcherService, IDialog dialog, INotificationService notificationService,
         IActiveWallet activeWallet,
-        IWalletRoot walletRoot, 
-        IValidations validations)
+        IWalletRoot walletRoot,
+        IValidations validations,
+        InstanceProfile instanceProfile)
     {
         LauncherService = launcherService;
         Dialog = dialog;
@@ -30,6 +32,7 @@ public partial class UIServices : ReactiveObject
         ActiveWallet = activeWallet;
         WalletRoot = walletRoot;
         Validations = validations;
+        InstancePrefix = instanceProfile.Value;
         this.WhenAnyValue(services => services.IsDarkThemeEnabled)
             .Do(isDarkTheme => Application.Current.RequestedThemeVariant = isDarkTheme ? ThemeVariant.Dark : ThemeVariant.Light)
             .Subscribe();
@@ -49,4 +52,5 @@ public partial class UIServices : ReactiveObject
     }
 
     public IValidations Validations { get; }
+    public string InstancePrefix { get; }
 }


### PR DESCRIPTION
## Summary
- add command-line parsing for an optional --profile argument in the desktop host and retain the value in a shared instance profile provider
- propagate the selected instance profile through the composition root so UIServices exposes the active prefix
- scope wallet and settings persistence to the profile by using profile-specific file paths

## Testing
- dotnet build src/Angor/Angor.sln *(fails: required .NET SDK 8.0.310 is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e544dd97fc832f8fb3f6524fa72d03